### PR TITLE
Hide the input code cells for ease of viewing

### DIFF
--- a/Nutritional_info_cereals.ipynb
+++ b/Nutritional_info_cereals.ipynb
@@ -14,7 +14,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "bd83b161-9818-47c0-9ba2-873abc968a00",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -255,7 +259,11 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "d72dadec-070d-487d-abd3-41d3e1757050",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -436,7 +444,11 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "18085d03-bb8a-4293-b452-661946b9b3c1",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -784,7 +796,11 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "b662a6fb-92bf-4457-bc81-4f56b1f40f6a",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
The code makes it sometimes not easy to understand text, therefore, hiding the code. It can be viewed by easy click to view option.